### PR TITLE
you can now hand-make struts

### DIFF
--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -29,6 +29,7 @@
 		return
 
 	// If is_brittle() returns true, these are only good for a single strike.
+	. += new/datum/stack_recipe/strut(src)
 	. += new/datum/stack_recipe/ashtray(src)
 	. += new/datum/stack_recipe/ring(src)
 	. += new/datum/stack_recipe/clipboard(src)

--- a/code/modules/materials/recipes_stacks.dm
+++ b/code/modules/materials/recipes_stacks.dm
@@ -97,3 +97,20 @@
 /datum/stack_recipe/tile/metal/pool
 	title = "pool floor tile"
 	result_type = /obj/item/stack/tile/pool
+	
+// handcraftable strut
+	
+/datum/stack_recipe/strut
+	title = "strut"
+	result_type = /obj/item/stack/material/strut
+	req_amount = 2
+	res_amount = 1
+	max_res_amount = 60
+	time = 10
+	difficulty = 2
+
+/datum/stack_recipe/strut/spawn_result(user, location, amount)
+	var/obj/item/stack/S = new result_type(location, amount, use_material)
+	if(user)
+		S.add_to_stacks(user, 1)
+	return S


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

you can now hand-craft struts out of 2 sheets of any material

this is very expensive but gives a solid use to "trash" materials like silicate if you don't mind your walls being hella flimsy

## Why and what will this PR improve

autolathes are broken atm makes struts unobtainable + lets people without access to power or autolathes make buildings at a higher cost

## Authorship

genessee

## Changelog

:cl:
add: handcraftable struts
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
